### PR TITLE
documentation: fix link to issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This approach allows for seamless audio playback across a wide range of browsers
 
 We love to hear from you so if you have questions, comments or find a bug in the project, let us know! You can either:
 
-- [Open an issue in this repository](https://github.com/deepgram-devs/deepgram-aura-tts-demo/issues)
+- [Open an issue in this repository](https://github.com/deepgram-devs/react-nowplaying/issues)
 - [Join the Deepgram Github Discussions Community](https://github.com/orgs/deepgram/discussions)
 - [Join the Deepgram Discord Community](https://discord.gg/xWRaCDBtW4)
 


### PR DESCRIPTION
The link to the issue tracker was broken, so I changed it to the issue tracker for this repository.