### PR TITLE
documentation: fix link to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ Stay updated with the changes and improvements made to our project by checking o
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE.md) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
The link to the license was broken, so I changed it to the license for this repository.